### PR TITLE
Configure shellcheck severity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,8 +40,6 @@ jobs:
           fail_on_error: true
           shellcheck_flags: --severity=style
 
-      - uses: bewuethr/shellcheck-action@v2
-
   dry-run:
     needs: id
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review
-          level: style
+          level: info
+          fail_on_error: true
+          shellcheck_flags: --severity=style
 
       - uses: bewuethr/shellcheck-action@v2
 


### PR DESCRIPTION
As `level` configures reviewdog and not shellcheck, `style` is not a valid value. Let's try with `level: info` instead as per https://github.com/reviewdog/action-shellcheck/issues/9#issuecomment-630780258.